### PR TITLE
Fix: Default option not selected in dropdown

### DIFF
--- a/src/app/orderform/orderform.component.html
+++ b/src/app/orderform/orderform.component.html
@@ -90,7 +90,7 @@
                   <div class="d-flex blindmatrix-v4-parameter-wrapper blindmatrix-v4-parameter-wrapper-list">
                     <label class="blindmatrix-v4-parameter-label">{{field.fieldname}}</label>
                     <select class="blindmatrix-v4-parameter-input" [formControlName]="field.labelnamecode" [id]="field.labelnamecode" (change)="onFieldChange(field.fieldid, $event)">
-                      <option selected value="">Select Option</option>
+                      <option value="">Select Option</option>
                       <option *ngFor="let option of option_data[field.fieldid] || field.optionsvalue" [value]="option.optionid">{{option.optionname}}</option>
                     </select>
                   </div>

--- a/src/app/orderform/orderform.component.ts
+++ b/src/app/orderform/orderform.component.ts
@@ -91,14 +91,18 @@ fetchInitialData(params: any): void {
     if (data) {
       const responseData = data[0].data;
       this.parameters_data = responseData;
-      console.log(responseData);
+
+      const formControls: { [key: string]: any } = {};
+      this.parameters_data.forEach(field => {
+        formControls[field.labelnamecode] = [''];
+      });
+      this.orderForm = this.fb.group(formControls);
+
       this.apiService.filterbasedlist(params, "", 5).subscribe((filterData: any) => {
- 
         const filterresponseData = filterData[0].data;
-         
-      
+
         this.parameters_data.forEach((field) => {
-        if( filterresponseData.optionarray[field.fieldid] != undefined){
+          if (filterresponseData.optionarray[field.fieldid] != undefined) {
             if (field.fieldtypeid == 3) {
               this.apiService.getOptionlist(
                 params,
@@ -114,7 +118,6 @@ fetchInitialData(params: any): void {
             }
           }
         });
-       
       });
     }
   });


### PR DESCRIPTION
The default "Select Option" was not being selected in dropdowns because the `selected` attribute was being used in conjunction with a reactive form.

This commit removes the `selected` attribute from the HTML and instead sets the initial value of the form controls to an empty string in the component's TypeScript file. This ensures that the default option is selected correctly.